### PR TITLE
Remove deprecated constructor

### DIFF
--- a/phplot/phplot.php
+++ b/phplot/phplot.php
@@ -397,7 +397,7 @@ class PHPlot
      *   $output_file : Filename for output. Omit, or NULL, or '' to mean no output file.
      *   $input_file : Path to a file to be used as background. Omit, NULL, or '' for none.
      */
-    function PHPlot($width=600, $height=400, $output_file=NULL, $input_file=NULL)
+    function __construct($width=600, $height=400, $output_file=NULL, $input_file=NULL)
     {
         $this->initialize('imagecreate', $width, $height, $output_file, $input_file);
     }


### PR DESCRIPTION
With PHP 7 following error occurs:

PHP Unknown: Methods with the same name as their class will not be constructors in a future version of PHP; PHPlot has a deprecated constructor in <...>\vendor\davefx\phplot\phplot\phplot.php on line 36

@see: https://wiki.php.net/rfc/remove_php4_constructors 
"Status: Deprecation Implemented (in PHP 7.0)"
